### PR TITLE
split by events

### DIFF
--- a/sframe_split.py
+++ b/sframe_split.py
@@ -119,7 +119,7 @@ if __name__ == "__main__":
                         missing.write(workdir+'/'+nameOfCycle+'.'+data_type[i]+'.'+names[i]+'_'+str(it)+'.root\n')
                         if resubmit_flag: resubmit(workdir+'/Stream_'+names[i],names[i]+'_'+str(it+1),workdir,header)
                 tot_prog += rootCounter
-                print names[i]+': ', rootCounter, NFiles[i], round(float(rootCounter)/float(NFiles[i]),3)
+                print '%30s: %4i %4i %.3f'% (names[i], rootCounter, NFiles[i], rootCounter/float(NFiles[i])), 'Done' if rootCounter == NFiles[i] else ''
                 if NFiles[i] == rootCounter: 
                     del_list.append(i)
                 i+=1
@@ -139,7 +139,7 @@ if __name__ == "__main__":
 
 
             #print 'Total progress', tot_prog
-            print '------------------------------------------------------'
+            print '-'*80
             if options.loop: time.sleep(30)
             if len(NFiles)==0: loop_check = False 
     


### PR DESCRIPTION
I decided not to create a new python file since I considered it overkill for just 11 lines of code. =) 

Apart from that, I just reused the exiting infrastructure in `write_job(...)`. The reason is that this is the correct way to do it (with NEventsSkip). And it gives you the benefit, that you actually run over the desired number of events for each job, not more or less, which is the behavior that one would naturally expect.

I hope you also like the new style of the printout. =)
