### PR TITLE
always setting Cacheable to False

### DIFF
--- a/Inf_Classes.py
+++ b/Inf_Classes.py
@@ -56,7 +56,7 @@ class InputData(object):
             if(item[0]=='NEventsMax'): self.NEventsMax = item[1]
             if(item[0]=='Type'): self.Type = item[1]
             if(item[0]=='Version'): self.Version = item[1]
-            if(item[0]=='Cacheable'): self.Cacheable = item[1]
+            if(item[0]=='Cacheable'): self.Cacheable = False
             if(item[0]=='NEventsSkip'): self.NEventsSkip = item[1]
         #print self.Version
         self.io_list =[]


### PR DESCRIPTION
sorry for spamming with PRs... the things is that I think most of the changes are important.

Like this one: something got confused because I had cacheable set to true in the config. So the jobs have been reading the cache file from another round of processing.. It's anyways not needed on the worker nodes.. I hope you agree.
