### PR TITLE
small fixes

### DIFF
--- a/Manager.py
+++ b/Manager.py
@@ -231,8 +231,11 @@ class JobManager(object):
                         process.resubmit[it] -= 1
                         self.numOfResubmit +=1
                 #If resubmits are used up go into failed
-                if batchstatus==0 and process.status == 0 and process.resubmit[it] ==0:
+                if batchstatus==0 and process.status == 0 and process.reachedBatch[it] and process.resubmit[it] ==0:
                     process.status = 4
+
+            if all(process.jobsDone):
+                process.status = 1
 
             process.rootFileCounter=rootFiles
             if not process.missingFiles and not process.status > 1:

--- a/Manager.py
+++ b/Manager.py
@@ -231,7 +231,13 @@ class JobManager(object):
                         process.resubmit[it] -= 1
                         self.numOfResubmit +=1
                 #If resubmits are used up go into failed
-                if batchstatus==0 and process.status == 0 and process.reachedBatch[it] and process.resubmit[it] ==0:
+                if (
+                    batchstatus==0 and
+                    process.status == 0 and
+                    process.resubmit[it] == 0 and
+                    process.reachedBatch[it] and
+                    not process.jobsDone[it]
+                ):
                     process.status = 4
 
             if all(process.jobsDone):

--- a/io_func.py
+++ b/io_func.py
@@ -147,12 +147,17 @@ class header(object):
 def get_number_of_events(Job, Version):
     InputData = filter(lambda inp: inp.Version==Version[0], Job.Job_Cylce[0].Cycle_InputData)[0]
     NEvents = 0
-    for entry in InputData.io_list.FileInfoList:
+    for entry in InputData.io_list.FileInfoList[:]:
             for name in entry:
                 if name.endswith('.root'):
                     f = ROOT.TFile(name)
                     try:
-                        NEvents += f.Get(InputData.io_list.InputTree[2]).GetEntriesFast()
+                        n = f.Get(InputData.io_list.InputTree[2]).GetEntriesFast()
+                        if n < 1:
+                            InputData.io_list.FileInfoList.remove(entry)
+                            break
+                        else:
+                            NEvents += n
                     except:
                         print name,'does not contain an InputTree'
                     f.Close()


### PR DESCRIPTION
The first commit fixes an issue with sframe: Files with an empty tree made sframe crash. This is fixed by removing these files from the list of files. Dominik discovered this.

The second and third commit set the status of a process to finished. The issue was that the jobs were actually completed, but probably never seen with qstat. Hence they stayed at failed and sframe_batch did not exit.

Sometimes a process is shows as failed although it is fine. Nevertheless, it's now updated to transferred if all output has arrived.
