### PR TITLE
Stop PyROOT eating argv

### DIFF
--- a/io_func.py
+++ b/io_func.py
@@ -15,6 +15,8 @@ import time
 import ROOT
 import copy
 
+ROOT.PyConfig.IgnoreCommandLineOptions = True
+
 #my classes
 from Inf_Classes import *
 from batch_classes import *


### PR DESCRIPTION
Magic line to make ROOT not override argv, makes `-h` work.
Fixes #42 